### PR TITLE
[TASK] Remove l10n_mode mergeIfNotBlank

### DIFF
--- a/Configuration/TCA/Overrides/tt_address.php
+++ b/Configuration/TCA/Overrides/tt_address.php
@@ -98,7 +98,3 @@ $excludedFields = array_diff(
 foreach ($excludedFields as $field) {
     $GLOBALS['TCA']['tt_address']['columns'][$field]['l10n_mode'] = 'exclude';
 }
-
-foreach (\CDSRC\CdsrcTtAddressL18n\Utility\SettingsUtility::getSettings()->getTranslatableFields() as $field) {
-    $GLOBALS['TCA']['tt_address']['columns'][$field]['l10n_mode'] = 'mergeIfNotBlank';
-}


### PR DESCRIPTION
If I understood right, it seems not needed anymore, https://docs.typo3.org/typo3cms/extensions/core/Changelog/8.6/Breaking-79243-RemoveL10n_modeMergeIfNotBlank.html

https://docs.typo3.org/typo3cms/TCAReference/8.7/Columns/#l10n-mode